### PR TITLE
Add double click reset rotation slider to zero

### DIFF
--- a/NeuroRuler/GUI/main.py
+++ b/NeuroRuler/GUI/main.py
@@ -85,7 +85,9 @@ if not PATH_TO_UI_FILE.exists():
 PATH_TO_NR_LOGO: Path = Path("NeuroRuler") / "GUI" / "static" / "nr_logo.png"
 if not PATH_TO_NR_LOGO.exists():
     PATH_TO_NR_LOGO = Path(
-        pkg_resources.resource_filename("NeuroRuler.GUI", "static/nr_logo.png") # TODO: pkg_resources is deprecated
+        pkg_resources.resource_filename(
+            "NeuroRuler.GUI", "static/nr_logo.png"
+        )  # TODO: pkg_resources is deprecated
     )
 
 SETTINGS_VIEW_ENABLED: bool = True
@@ -166,10 +168,19 @@ class MainWindow(QMainWindow):
         self.next_button.clicked.connect(self.next_img)
         self.previous_button.clicked.connect(self.previous_img)
         self.apply_button.clicked.connect(self.settings_export_view_toggle)
+
         self.x_slider.valueChanged.connect(self.rotate_x)
+        self.x_rotation_label.binded_slider = self.x_slider
+
         self.y_slider.valueChanged.connect(self.rotate_y)
+        self.y_rotation_label.binded_slider = self.y_slider
+
         self.z_slider.valueChanged.connect(self.rotate_z)
+        self.z_rotation_label.binded_slider = self.z_slider
+
         self.slice_slider.valueChanged.connect(self.slice_update)
+        self.slice_num_label.binded_slider = self.slice_slider
+
         self.reset_button.clicked.connect(self.reset_settings)
         self.smoothing_preview_button.clicked.connect(self.render_smooth_slice)
         self.otsu_radio_button.clicked.connect(self.disable_binary_threshold_inputs)

--- a/NeuroRuler/GUI/mainwindow.ui
+++ b/NeuroRuler/GUI/mainwindow.ui
@@ -114,7 +114,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="QLabel" name="x_rotation_label">
+           <widget class="QClickableLabel" name="x_rotation_label">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -165,7 +165,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="QLabel" name="y_rotation_label">
+           <widget class="QClickableLabel" name="y_rotation_label">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -216,7 +216,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="QLabel" name="z_rotation_label">
+           <widget class="QClickableLabel" name="z_rotation_label">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -1171,7 +1171,7 @@ In Slicer, the images are 3D and the default (.0625) time step will provide a st
      <x>0</x>
      <y>0</y>
      <width>1308</width>
-     <height>24</height>
+     <height>22</height>
     </rect>
    </property>
    <property name="nativeMenuBar">
@@ -1514,6 +1514,13 @@ In Slicer, the images are 3D and the default (.0625) time step will provide a st
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QClickableLabel</class>
+   <extends>QLabel</extends>
+   <header location="global">NeuroRuler.GUI.qclickablelabel</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
  <buttongroups>

--- a/NeuroRuler/GUI/qclickablelabel.py
+++ b/NeuroRuler/GUI/qclickablelabel.py
@@ -1,0 +1,27 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QLabel
+
+
+class QClickableLabel(QLabel):
+    """Clickable QLabel
+
+    When double clicked, the binded slider will be set to 0.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._binded_slider = None
+
+    @property
+    def binded_slider(self):
+        return self._binded_slider
+
+    @binded_slider.setter
+    def binded_slider(self, slider):
+        self._binded_slider = slider
+
+    def mouseDoubleClickEvent(self, event):
+        if event.buttons() == Qt.MouseButton.LeftButton:
+            if self.binded_slider:
+                self.binded_slider.setValue(0)


### PR DESCRIPTION
Implements part of #100. Now double click x/y/z rotation label will reset slider value to zero.

